### PR TITLE
Improve the handling for unsupported Gradle versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Foojay Toolchains Plugin
 
-The `org.gradle.disco-toolchains` plugin provides a [repository for downloading JVMs](https://docs.gradle.org/current/userguide/toolchains.html#sub:download_repositories). It is based on the [foojay DiscoAPI](https://github.com/foojayio/discoapi).
+The `org.gradle.disco-toolchains` plugin provides a [repository for downloading JVMs](https://docs.gradle.org/current/userguide/toolchains.html#sub:download_repositories).
+It is based on the [foojay DiscoAPI](https://github.com/foojayio/discoapi).
+Requires Gradle 7.6 or later to work.
 
 # Usage
 

--- a/foojay-resolver/release-notes-0.4.0.txt
+++ b/foojay-resolver/release-notes-0.4.0.txt
@@ -1,1 +1,0 @@
-- Try distributions one-by-one if no vendor is specified

--- a/foojay-resolver/release-notes-0.5.0.txt
+++ b/foojay-resolver/release-notes-0.5.0.txt
@@ -1,0 +1,1 @@
+- Generate useful error message if used with unsupported Gradle versions

--- a/foojay-resolver/src/functionalTest/kotlin/org/gradle/toolchains/foojay/AbstractFoojayToolchainsPluginFunctionalTest.kt
+++ b/foojay-resolver/src/functionalTest/kotlin/org/gradle/toolchains/foojay/AbstractFoojayToolchainsPluginFunctionalTest.kt
@@ -4,7 +4,6 @@ import org.gradle.testkit.runner.GradleRunner
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
-import kotlin.test.assertTrue
 
 abstract class AbstractFoojayToolchainsPluginFunctionalTest {
 
@@ -28,7 +27,7 @@ abstract class AbstractFoojayToolchainsPluginFunctionalTest {
         """.trimIndent())
     }
 
-    protected fun runTest(settings: String) {
+    protected fun runner(settings: String): GradleRunner {
         settingsFile.writeText(settings)
         buildFile.writeText("""
                 plugins {
@@ -42,16 +41,11 @@ abstract class AbstractFoojayToolchainsPluginFunctionalTest {
                 }
             """.trimIndent())
 
-        // Run the build
-        val runner = GradleRunner.create()
-        runner.forwardOutput()
-        runner.withPluginClasspath()
-        runner.withArguments(listOf("--info", "-g", homeDir.absolutePath, "compileJava"))
-        runner.withProjectDir(projectDir)
-        val result = runner.build()
-
-        // Verify the result
-        assertTrue(result.output.contains("Installed toolchain from https://api.foojay.io/disco/"))
+        return GradleRunner.create()
+            .forwardOutput()
+            .withPluginClasspath()
+            .withArguments(listOf("--info", "-g", homeDir.absolutePath, "compileJava"))
+            .withProjectDir(projectDir)
     }
 
     private fun getDifferentJavaVersion() = when {

--- a/foojay-resolver/src/functionalTest/kotlin/org/gradle/toolchains/foojay/FoojayToolchainsConventionPluginFunctionalTest.kt
+++ b/foojay-resolver/src/functionalTest/kotlin/org/gradle/toolchains/foojay/FoojayToolchainsConventionPluginFunctionalTest.kt
@@ -1,6 +1,7 @@
 package org.gradle.toolchains.foojay
 
 import kotlin.test.Test
+import kotlin.test.assertTrue
 
 class FoojayToolchainsConventionPluginFunctionalTest: AbstractFoojayToolchainsPluginFunctionalTest() {
 
@@ -11,7 +12,25 @@ class FoojayToolchainsConventionPluginFunctionalTest: AbstractFoojayToolchainsPl
                 id("org.gradle.toolchains.foojay-resolver-convention") version "$pluginVersion"
             }
         """.trimIndent()
-        runTest(settings)
+
+        val result = runner(settings).build()
+
+        assertTrue(result.output.contains("Installed toolchain from https://api.foojay.io/disco/"))
+    }
+
+    @Test
+    fun `generates useful error for unsupported Gradle versions`() {
+        val settings = """
+            plugins {
+                id("org.gradle.toolchains.foojay-resolver-convention") version "$pluginVersion"
+            }
+        """.trimIndent()
+
+        val result = runner(settings)
+                .withGradleVersion("7.5")
+                .buildAndFail()
+
+        assertTrue(result.output.contains("FoojayToolchainsPlugin needs Gradle version 7.6 or higher"))
     }
 
 }

--- a/foojay-resolver/src/functionalTest/kotlin/org/gradle/toolchains/foojay/FoojayToolchainsPluginFunctionalTest.kt
+++ b/foojay-resolver/src/functionalTest/kotlin/org/gradle/toolchains/foojay/FoojayToolchainsPluginFunctionalTest.kt
@@ -1,6 +1,7 @@
 package org.gradle.toolchains.foojay
 
 import kotlin.test.Test
+import kotlin.test.assertTrue
 
 class FoojayToolchainsPluginFunctionalTest: AbstractFoojayToolchainsPluginFunctionalTest() {
 
@@ -21,6 +22,34 @@ class FoojayToolchainsPluginFunctionalTest: AbstractFoojayToolchainsPluginFuncti
                 }
             }
         """.trimIndent()
-        runTest(settings)
+
+        val result = runner(settings).build()
+
+        assertTrue(result.output.contains("Installed toolchain from https://api.foojay.io/disco/"))
+    }
+
+    @Test
+    fun `generates useful error for unsupported Gradle versions`() {
+        val settings = """
+            plugins {
+                id("org.gradle.toolchains.foojay-resolver") version "$pluginVersion"
+            }
+            
+            toolchainManagement {
+                jvm { 
+                    javaRepositories {
+                        repository("foojay") { 
+                            resolverClass.set(org.gradle.toolchains.foojay.FoojayToolchainResolver::class.java)
+                        }
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val result = runner(settings)
+                .withGradleVersion("7.5")
+                .buildAndFail()
+
+        assertTrue(result.output.contains("FoojayToolchainsPlugin needs Gradle version 7.6 or higher"))
     }
 }

--- a/foojay-resolver/src/main/kotlin/org/gradle/toolchains/foojay/FoojayApi.kt
+++ b/foojay-resolver/src/main/kotlin/org/gradle/toolchains/foojay/FoojayApi.kt
@@ -29,17 +29,19 @@ class FoojayApi {
 
     val distributions = mutableListOf<Distribution>()
 
-    fun toUri(
-        version: JavaLanguageVersion,
-        vendor: JvmVendorSpec,
-        implementation: JvmImplementation,
-        operatingSystem: OperatingSystem,
-        architecture: Architecture
-    ): URI? {
+    fun toUri(links: Links?): URI? = links?.pkg_download_redirect
+
+    fun toLinks(
+            version: JavaLanguageVersion,
+            vendor: JvmVendorSpec,
+            implementation: JvmImplementation,
+            operatingSystem: OperatingSystem,
+            architecture: Architecture
+    ): Links? {
         val distributions = match(vendor, implementation, version)
         return distributions.asSequence().mapNotNull { distribution ->
             val downloadPackage = match(distribution.api_parameter, version, operatingSystem, architecture)
-            downloadPackage?.links?.pkg_download_redirect
+            downloadPackage?.links
         }.firstOrNull()
     }
 

--- a/foojay-resolver/src/main/kotlin/org/gradle/toolchains/foojay/FoojayToolchainResolver.kt
+++ b/foojay-resolver/src/main/kotlin/org/gradle/toolchains/foojay/FoojayToolchainResolver.kt
@@ -12,13 +12,14 @@ abstract class FoojayToolchainResolver: JavaToolchainResolver {
     override fun resolve(request: JavaToolchainRequest): Optional<JavaToolchainDownload> {
         val spec = request.javaToolchainSpec
         val platform = request.buildPlatform
-        val uri = api.toUri(
+        val links = api.toLinks(
             spec.languageVersion.get(),
             spec.vendor.get(),
             spec.implementation.get(),
             platform.operatingSystem,
             platform.architecture
         )
+        val uri = api.toUri(links)
         return Optional.ofNullable(uri).map(JavaToolchainDownload::fromUri)
     }
 }

--- a/foojay-resolver/src/main/kotlin/org/gradle/toolchains/foojay/FoojayToolchainsPlugin.kt
+++ b/foojay-resolver/src/main/kotlin/org/gradle/toolchains/foojay/FoojayToolchainsPlugin.kt
@@ -5,19 +5,21 @@ package org.gradle.toolchains.foojay
 
 import org.gradle.api.Plugin
 import org.gradle.api.initialization.Settings
+import org.gradle.api.internal.SettingsInternal
 import org.gradle.jvm.toolchain.JavaToolchainResolverRegistry
-import javax.inject.Inject
+import org.gradle.util.GradleVersion
 
 @Suppress("unused")
 abstract class FoojayToolchainsPlugin: Plugin<Settings> {
 
-    @get:Inject
-    protected abstract val toolchainResolverRegistry: JavaToolchainResolverRegistry
-
     override fun apply(settings: Settings) {
+        if (GradleVersion.current().baseVersion < GradleVersion.version("7.6")) {
+            throw RuntimeException("${FoojayToolchainsPlugin::class.simpleName} needs Gradle version 7.6 or higher")
+        }
+
         settings.plugins.apply("jvm-toolchain-management")
 
-        val registry: JavaToolchainResolverRegistry = toolchainResolverRegistry
+        val registry = (settings as SettingsInternal).services.get(JavaToolchainResolverRegistry::class.java)
         registry.register(FoojayToolchainResolver::class.java)
     }
 

--- a/foojay-resolver/src/test/kotlin/org/gradle/toolchains/foojay/FoojayApiTest.kt
+++ b/foojay-resolver/src/test/kotlin/org/gradle/toolchains/foojay/FoojayApiTest.kt
@@ -22,19 +22,19 @@ class FoojayApiTest {
     @Test
     fun `download URI provided correctly`() {
         assertDownloadUri(
-            "https://api.foojay.io/disco/v3.0/ids/c3f7c076bf335d1061c74f7fab42bb89/redirect",
-            8, any(), false, OperatingSystem.MAC_OS, Architecture.AARCH64
-        ) // zulu8.66.0.15-ca-jdk8.0.352-macosx_aarch64.tar.gz
+                "https://api.foojay.io/disco/v3.0/ids/b7249cc4ea86971f6f2ec990f241992f/redirect",
+                8, any(), false, OperatingSystem.MAC_OS, Architecture.AARCH64
+        ) // zulu8.68.0.21-ca-jdk8.0.362-macosx_aarch64.zip
 
         assertDownloadUri(
-            "https://api.foojay.io/disco/v3.0/ids/2b5dc4d917750eba32eb1acf62cec901/redirect",
-            11, ADOPTIUM, false, OperatingSystem.MAC_OS, Architecture.AARCH64
-        ) // OpenJDK11U-jdk_aarch64_mac_hotspot_11.0.17_8.tar.gz
+                "https://api.foojay.io/disco/v3.0/ids/7c047fee9eda8fba1fe1925111d3faa2/redirect",
+                11, ADOPTIUM, false, OperatingSystem.MAC_OS, Architecture.AARCH64
+        ) // OpenJDK11U-jdk_aarch64_mac_hotspot_11.0.18_10.tar.gz
 
         assertDownloadUri(
-            "https://api.foojay.io/disco/v3.0/ids/9927d38888344a93f3803dfd0366a6e3/redirect",
-            11, GRAAL_VM, false, OperatingSystem.MAC_OS, Architecture.AARCH64
-        ) // graalvm-ce-java11-darwin-aarch64-22.3.0.tar.gz
+                "https://api.foojay.io/disco/v3.0/ids/7f094bee7c283c8a886273445e950130/redirect",
+                11, GRAAL_VM, false, OperatingSystem.MAC_OS, Architecture.AARCH64
+        ) // graalvm-ce-java11-darwin-aarch64-22.3.1.tar.gz
 
         assertDownloadUri(
                 "https://api.foojay.io/disco/v3.0/ids/5b31509900ab21f4cd92dbc454b3c7e2/redirect",
@@ -52,8 +52,8 @@ class FoojayApiTest {
         ) // ibm-semeru-open-jdk_x64_mac_16.0.2_7_openj9-0.27.0.tar.gz
 
         assertDownloadUri(
-            "https://api.foojay.io/disco/v3.0/ids/871fe4e17cc2d5625fc5ca5f4027affd/redirect",
-            16, GRAAL_VM, false, OperatingSystem.LINUX, Architecture.X86_64
+                "https://api.foojay.io/disco/v3.0/ids/871fe4e17cc2d5625fc5ca5f4027affd/redirect",
+                16, GRAAL_VM, false, OperatingSystem.LINUX, Architecture.X86_64
         ) // graalvm-ce-java16-linux-amd64-21.2.0.tar.gz
 
         assertDownloadUri(
@@ -145,7 +145,7 @@ class FoojayApiTest {
         assertEquals("tar.gz", p.archive_type)
         assertEquals("temurin", p.distribution)
         assertEquals(11, p.jdk_version)
-        assertEquals("11.0.17", p.distribution_version)
+        assertEquals("11.0.18", p.distribution_version)
         assertEquals("linux", p.operating_system)
         assertEquals("x64", p.architecture)
         assertEquals("jdk", p.package_type)
@@ -159,14 +159,14 @@ class FoojayApiTest {
             os: OperatingSystem,
             arch: Architecture
     ) {
-        val uri = api.toUri(
+        val links = api.toLinks(
                 of(javaVersion),
-            vendor,
-            if (isJ9) J9 else VENDOR_SPECIFIC,
-            os,
-            arch
+                vendor,
+                if (isJ9) J9 else VENDOR_SPECIFIC,
+                os,
+                arch
         )
-        assertEquals(expected, uri.toString())
+        assertEquals(expected, api.toUri(links).toString(), "Expected URI differs from actual, for details see ${links?.pkg_info_uri}")
     }
 
     private fun vendorSpec(vendorName: String): JvmVendorSpec = matching(vendorName)


### PR DESCRIPTION
Fixes: #18 

This is done by:
 - generating a useful error message at runtime
 - stating the version requirements in the docs

 Change has also been added to release notes for next version.