### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+registries:
+  gradle-plugin-portal:
+    type: maven-repository
+    url: https://plugins.gradle.org/m2
+
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    registries:
+      - gradle-plugin-portal
+    schedule:
+      interval: "daily"
+      time: "02:00"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "02:00"


### PR DESCRIPTION
This goes a bit further of #52 and adds dependabot to make sure we are always using the latest versions of dependencies 🙃.

I copied the config from [here](https://github.com/gradle/wrapper-upgrade-gradle-plugin/blob/main/.github%2Fdependabot.yml) and removed the dummy auth (because this is not required). 