### PR TITLE
Wrapper upgrade plugin

### DIFF
--- a/.github/workflows/wrapper-upgrade.yml
+++ b/.github/workflows/wrapper-upgrade.yml
@@ -1,0 +1,27 @@
+name: Wrapper Upgrade
+
+on:
+  schedule:
+    - cron:  '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  upgrade_wrapper:
+    runs-on: ubuntu-latest
+    env:
+      WRAPPER_UPGRADE_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Set up Git configuration
+        run: |
+          git config --global user.email "bot-githubaction@gradle.com"
+          git config --global user.name "bot-githubaction"
+          git config --global url."https://unused-username:${WRAPPER_UPGRADE_GIT_TOKEN}@github.com/".insteadOf "https://github.com/"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Upgrade Wrappers
+        run: ./gradlew clean upgradeGradleWrapperAll

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    id("base")
+    id("org.gradle.wrapper-upgrade") version "0.11.4"
+}
+
+wrapperUpgrade {
+    gradle {
+        register("foojayToolchains") {
+            repo.set("gradle/foojay-toolchains")
+        }
+    }
+}


### PR DESCRIPTION
fixes #59 

The GH aciton workflow was more or less copied from the gradle-wrapper-upgrade project itself.
👉 [ Link to their workflow file](https://github.com/gradle/wrapper-upgrade-gradle-plugin/blob/fa846e89de0c929df75400d66e42beb2c7d05062/.github/workflows/wrapper-upgrade-execution.yml)

Please notice that I removed the commit signing part here.
I'm not sure if this is/was a requirement for you. But to make this PR easy and straightforward I left them out.
Let me know if you want to include it.
If so, add the key and password to this repository (if not already added via the Gradle GitHub organisation) and I will add the respective code parts.

To note is also that the pull request create by this workflow does not run any tests❗ 
This is due to the fact that we are using the `secrets.GITHUB_TOKEN`.
Any PR that were created by an action can't trigger other actions by design.

So in case we want to run tests also on wrapper upgrade PRs (which make sense IMHO), you have to provide another secret and invite the respective user of this secret to this repo as collaborator with write access.
You might want to use your `bot-githubaction` for that 🙃 Seems this bot is designed for such tasks 😁 

[Here is an example of how such an PR could look like](https://github.com/gradle/wrapper-upgrade-gradle-plugin/pull/188).
Notice that it doesn't run any tests. Only the DCO check runs (because of I don't know the reason 🙈 )


