### PR TITLE
Better api error handling

### DIFF
--- a/foojay-resolver/build.gradle.kts
+++ b/foojay-resolver/build.gradle.kts
@@ -24,6 +24,7 @@ java {
 
 dependencies {
     implementation("com.google.code.gson:gson:2.10.1")
+    implementation("org.jetbrains:annotations:24.0.1")
 }
 
 gradlePlugin {

--- a/foojay-resolver/src/main/kotlin/org/gradle/toolchains/foojay/FoojayApi.kt
+++ b/foojay-resolver/src/main/kotlin/org/gradle/toolchains/foojay/FoojayApi.kt
@@ -10,8 +10,8 @@ import java.nio.charset.StandardCharsets
 import java.util.concurrent.TimeUnit
 
 internal interface Api {
-    fun fetchDistributions(params: Map<String, String>): String
-    fun fetchPackages(params: Map<String, String>): String
+    fun fetchDistributions(params: Map<String, String>): Result<String>
+    fun fetchPackages(params: Map<String, String>): Result<String>
 }
 
 internal class FoojayApi : Api {
@@ -23,10 +23,10 @@ internal class FoojayApi : Api {
     private val DISTRIBUTIONS_ENDPOINT = "$ENDPOINT_ROOT/distributions"
     private val PACKAGES_ENDPOINT = "$ENDPOINT_ROOT/packages"
 
-    override fun fetchDistributions(params: Map<String, String>): String =
+    override fun fetchDistributions(params: Map<String, String>): Result<String> =
         createConnection(DISTRIBUTIONS_ENDPOINT, params).use { readResponse(this) }
 
-    override fun fetchPackages(params: Map<String, String>): String =
+    override fun fetchPackages(params: Map<String, String>): Result<String> =
         createConnection(PACKAGES_ENDPOINT, params).use { readResponse(this) }
 
     private fun createConnection(endpoint: String, params: Map<String, String>): HttpURLConnection {
@@ -48,12 +48,12 @@ internal class FoojayApi : Api {
         }
     }
 
-    private fun readResponse(con: HttpURLConnection): String {
+    private fun readResponse(con: HttpURLConnection): Result<String> {
         val status = con.responseCode
         if (status != HttpURLConnection.HTTP_OK) {
-            throw GradleException("Requesting vendor list failed: ${readContent(con.errorStream)}")
+            return Result.failure(GradleException("Requesting vendor list failed: ${readContent(con.errorStream)}"))
         }
-        return readContent(con.inputStream)
+        return Result.success(readContent(con.inputStream))
     }
 
     private fun readContent(stream: InputStream): String = stream.bufferedReader().use(BufferedReader::readText)

--- a/foojay-resolver/src/main/kotlin/org/gradle/toolchains/foojay/FoojayService.kt
+++ b/foojay-resolver/src/main/kotlin/org/gradle/toolchains/foojay/FoojayService.kt
@@ -1,0 +1,92 @@
+package org.gradle.toolchains.foojay
+
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JvmImplementation
+import org.gradle.jvm.toolchain.JvmVendorSpec
+import org.gradle.platform.Architecture
+import org.gradle.platform.OperatingSystem
+import org.jetbrains.annotations.VisibleForTesting
+import java.net.URI
+
+internal interface Service {
+    fun findMatchingDownloadUri(
+        version: JavaLanguageVersion,
+        vendor: JvmVendorSpec,
+        implementation: JvmImplementation,
+        operatingSystem: OperatingSystem,
+        architecture: Architecture
+    ): URI?
+}
+
+internal class FoojayService(
+    private val api: Api
+) : Service {
+
+    private val distributions = mutableListOf<Distribution>()
+
+    override fun findMatchingDownloadUri(
+        version: JavaLanguageVersion,
+        vendor: JvmVendorSpec,
+        implementation: JvmImplementation,
+        operatingSystem: OperatingSystem,
+        architecture: Architecture
+    ): URI? = findMatchingDistributions(vendor, implementation, version)
+        .asSequence()
+        .mapNotNull { distribution ->
+            val matchingPackage = findMatchingPackage(
+                distribution.api_parameter,
+                version,
+                operatingSystem,
+                architecture
+            )
+            matchingPackage?.links
+        }
+        .firstOrNull()
+        ?.pkg_download_redirect
+
+    @VisibleForTesting()
+    internal fun findMatchingDistributions(
+        vendor: JvmVendorSpec,
+        implementation: JvmImplementation,
+        version: JavaLanguageVersion
+    ): List<Distribution> {
+        fetchDistributionsIfMissing()
+        return match(distributions, vendor, implementation, version)
+    }
+
+    private fun fetchDistributionsIfMissing() {
+        if (distributions.isEmpty()) {
+            val distributionJson = api.fetchDistributions(
+                mapOf("include_versions" to "true", "include_synonyms" to "true")
+            )
+
+            distributions.addAll(parseDistributions(distributionJson))
+        }
+    }
+
+    @VisibleForTesting
+    internal fun findMatchingPackage(
+        distributionName: String,
+        version: JavaLanguageVersion,
+        operatingSystem: OperatingSystem,
+        architecture: Architecture
+    ): Package? {
+        val versionApiKey = when {
+            distributionName.startsWith("graalvm_community") -> "version"
+            else -> "jdk_version"
+        }
+
+        val packagesJson = api.fetchPackages(
+            mapOf(
+                versionApiKey to "$version",
+                "distro" to distributionName,
+                "operating_system" to operatingSystem.toApiValue(),
+                "latest" to "available",
+                "directly_downloadable" to "true"
+            )
+        )
+
+        val packages = parsePackages(packagesJson)
+        return match(packages, architecture)
+    }
+}

--- a/foojay-resolver/src/main/kotlin/org/gradle/toolchains/foojay/FoojayToolchainResolver.kt
+++ b/foojay-resolver/src/main/kotlin/org/gradle/toolchains/foojay/FoojayToolchainResolver.kt
@@ -1,5 +1,6 @@
 package org.gradle.toolchains.foojay
 
+import org.gradle.api.logging.Logging
 import org.gradle.jvm.toolchain.JavaToolchainDownload
 import org.gradle.jvm.toolchain.JavaToolchainRequest
 import org.gradle.jvm.toolchain.JavaToolchainResolver
@@ -19,6 +20,11 @@ abstract class FoojayToolchainResolver : JavaToolchainResolver {
             platform.operatingSystem,
             platform.architecture
         )
-        return Optional.ofNullable(matchingDownloadUri).map(JavaToolchainDownload::fromUri)
+        if (matchingDownloadUri.isFailure) logWarning()
+        return Optional.ofNullable(matchingDownloadUri.getOrThrow()).map(JavaToolchainDownload::fromUri)
+    }
+
+    private fun logWarning() {
+        Logging.getLogger(FoojayToolchainResolver::class.java).warn("Failed to resolve Java toolchain")
     }
 }

--- a/foojay-resolver/src/main/kotlin/org/gradle/toolchains/foojay/FoojayToolchainResolver.kt
+++ b/foojay-resolver/src/main/kotlin/org/gradle/toolchains/foojay/FoojayToolchainResolver.kt
@@ -21,7 +21,7 @@ abstract class FoojayToolchainResolver : JavaToolchainResolver {
             platform.architecture
         )
         if (matchingDownloadUri.isFailure) logWarning()
-        return Optional.ofNullable(matchingDownloadUri.getOrThrow()).map(JavaToolchainDownload::fromUri)
+        return Optional.ofNullable(matchingDownloadUri.getOrNull()).map(JavaToolchainDownload::fromUri)
     }
 
     private fun logWarning() {

--- a/foojay-resolver/src/main/kotlin/org/gradle/toolchains/foojay/FoojayToolchainResolver.kt
+++ b/foojay-resolver/src/main/kotlin/org/gradle/toolchains/foojay/FoojayToolchainResolver.kt
@@ -3,23 +3,22 @@ package org.gradle.toolchains.foojay
 import org.gradle.jvm.toolchain.JavaToolchainDownload
 import org.gradle.jvm.toolchain.JavaToolchainRequest
 import org.gradle.jvm.toolchain.JavaToolchainResolver
-import java.util.*
+import java.util.Optional
 
-abstract class FoojayToolchainResolver: JavaToolchainResolver {
+abstract class FoojayToolchainResolver : JavaToolchainResolver {
 
-    private val api: FoojayApi = FoojayApi()
+    private val service: FoojayService = FoojayService(FoojayApi())
 
     override fun resolve(request: JavaToolchainRequest): Optional<JavaToolchainDownload> {
         val spec = request.javaToolchainSpec
         val platform = request.buildPlatform
-        val links = api.toLinks(
+        val matchingDownloadUri = service.findMatchingDownloadUri(
             spec.languageVersion.get(),
             spec.vendor.get(),
             spec.implementation.get(),
             platform.operatingSystem,
             platform.architecture
         )
-        val uri = api.toUri(links)
-        return Optional.ofNullable(uri).map(JavaToolchainDownload::fromUri)
+        return Optional.ofNullable(matchingDownloadUri).map(JavaToolchainDownload::fromUri)
     }
 }

--- a/foojay-resolver/src/test/kotlin/org/gradle/toolchains/foojay/FoojayServiceTest.kt
+++ b/foojay-resolver/src/test/kotlin/org/gradle/toolchains/foojay/FoojayServiceTest.kt
@@ -176,7 +176,7 @@ class FoojayServiceTest {
     private fun assertMatchedDistributions(vendor: JvmVendorSpec, implementation: JvmImplementation, version: Int, vararg expectedDistributions: String) {
         assertEquals(
                 listOf(*expectedDistributions),
-                service.findMatchingDistributions(vendor, implementation, of(version)).map { it.name },
+                service.findMatchingDistributions(vendor, implementation, of(version)).getOrThrow().map { it.name },
                 "Mismatch in matching distributions for vendor: $vendor, implementation: $implementation, version: $version"
         )
     }
@@ -184,9 +184,9 @@ class FoojayServiceTest {
     @ParameterizedTest(name = "can resolve arbitrary vendors (Java {0})")
     @ValueSource(ints = [8, 11, 16])
     fun `can resolve arbitrary vendors`(version: Int) {
-        assertEquals("ZuluPrime", service.findMatchingDistributions(vendorSpec("zuluprime"), VENDOR_SPECIFIC, of(version)).firstOrNull()?.name)
-        assertEquals("ZuluPrime", service.findMatchingDistributions(vendorSpec("zUluprIme"), VENDOR_SPECIFIC, of(version)).firstOrNull()?.name)
-        assertEquals("JetBrains", service.findMatchingDistributions(vendorSpec("JetBrains"), VENDOR_SPECIFIC, of(version)).firstOrNull()?.name)
+        assertEquals("ZuluPrime", service.findMatchingDistributions(vendorSpec("zuluprime"), VENDOR_SPECIFIC, of(version)).getOrThrow().firstOrNull()?.name)
+        assertEquals("ZuluPrime", service.findMatchingDistributions(vendorSpec("zUluprIme"), VENDOR_SPECIFIC, of(version)).getOrThrow().firstOrNull()?.name)
+        assertEquals("JetBrains", service.findMatchingDistributions(vendorSpec("JetBrains"), VENDOR_SPECIFIC, of(version)).getOrThrow().firstOrNull()?.name)
     }
 
     @Test
@@ -217,7 +217,7 @@ class FoojayServiceTest {
                 os,
                 arch
         )
-        val uriString = matchingUri?.toString() ?: ""
+        val uriString = matchingUri.map { it?.toString() }.getOrNull() ?: ""
         assertTrue(expected.matches(uriString), "Expected URI differs from actual, got $uriString")
     }
 


### PR DESCRIPTION
All I wanted to fix is #47 .. suddently it ended up in a short rewrite 😅 
fixes #47 

Main fix is here:
Instead of throwing a `GradleException` in case API return != 200 status code, we return an `Result.failure` (Kotlin builtin).
This is how it look before this PR:
https://github.com/gradle/foojay-toolchains/blob/15211a0a6958f43ca711a5ffdf3013c449effb4c/foojay-resolver/src/main/kotlin/org/gradle/toolchains/foojay/FoojayApi.kt#L107-L109

Now it looks like this
```kotlin
        if (status != HttpURLConnection.HTTP_OK) {
            return Result.failure(GradleException("Requesting vendor list failed: ${readContent(con.errorStream)}"))
        }
```
The result will be bubbled up until it reaches the `Resolver`.
The Resolver will then do a logging (`warn` level) and return an `Optional.empty`.

The resulting message will then instead of one of the linked issue be like:
```
* What went wrong:
A problem occurred configuring project ':domain:map'.
> Failed to calculate the value of task ':domain:map:compileJava' property 'javaCompiler'.
   > Cannot find a Java installation on your machine matching this tasks requirements: {languageVersion=18, vendor=AZUL, implementation=vendor-specific} for MAC_OS on aarch64.
      > No locally installed toolchains match and the configured toolchain download repositories aren't able to provide a match either.
```
(Ignore the case that a java 18 Zulu package is available, for testing purpose I modified the result.success case to be an error 😉 )

This is the "default" error message that will be displayed by the Gradle build tool itself and I think it is more obvious (but more generic) than the one before.

Furthermore, if running with `--info` (or something) the output includes `Failed to resolve Java toolchain`.
Not sure if we want to enhance this? 🤔 
We can 🤷 😁 

This doesn't "fix the problem" in case of foojay api is down AND there is no local jdk installed.
In this case users are "locked in" and can't work until foojay api is up again.
But I guess providing a fallback is out of scope of this plugin ... 
Maybe we can enhance the error message with "If foojay api is down, use one of the locally installed java versions instead: [listOfLocallyAvailableJdks]"

What do you think? 🤔 

Whatever, about the rewrite.. 😁 
I extracted a `FoojayService` out of `FoojayApi`.
`FoojayApi` has only the responsibility to make the connection and return an `Result<JsonString>`.
Thats it.
`FoojayService` will handle the `findMatchingDistribution`, followed by the `findMatchingPackag` logic... 
I have the feeling this makes things a bit nicer ...



