### PR TITLE
Add link to vendors

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The main thing the plugin does is to match [Gradle's toolchain specifications](h
 
 ## Vendors
 
-There is mostly a 1-to-1 relationship between the DiscoAPI's distributions and Gradle vendors.
+There is mostly a 1-to-1 relationship between the DiscoAPI's distributions and [Gradle vendors](https://docs.gradle.org/current/userguide/toolchains.html#sec:vendors).
 The plugin works with the following mapping:
 
 | Gradle JVM Vendor       | Foojay Distribution       |


### PR DESCRIPTION
When not in the context of toolchains, it is hard to know which key and value to put where. Links can help. This PR adds a link to the gradle documentation. I know that this documentaiton is also googable and links could change. However, I still hope that [cool UIRs don't change](https://www.w3.org/Provider/Style/URI) and that links help users to move faster.