### PR TITLE
allow using x64 java on arm macs

### DIFF
--- a/foojay-resolver/src/main/kotlin/org/gradle/toolchains/foojay/FoojayToolchainResolver.kt
+++ b/foojay-resolver/src/main/kotlin/org/gradle/toolchains/foojay/FoojayToolchainResolver.kt
@@ -20,7 +20,6 @@ abstract class FoojayToolchainResolver: JavaToolchainResolver {
             platform.architecture
         )?.links
         val uri = api.toUri(links)
-
         return Optional.ofNullable(uri).map(JavaToolchainDownload::fromUri)
     }
 }

--- a/foojay-resolver/src/main/kotlin/org/gradle/toolchains/foojay/FoojayToolchainResolver.kt
+++ b/foojay-resolver/src/main/kotlin/org/gradle/toolchains/foojay/FoojayToolchainResolver.kt
@@ -3,8 +3,6 @@ package org.gradle.toolchains.foojay
 import org.gradle.jvm.toolchain.JavaToolchainDownload
 import org.gradle.jvm.toolchain.JavaToolchainRequest
 import org.gradle.jvm.toolchain.JavaToolchainResolver
-import org.gradle.platform.Architecture
-import org.gradle.platform.OperatingSystem
 import java.util.*
 
 abstract class FoojayToolchainResolver: JavaToolchainResolver {
@@ -21,18 +19,7 @@ abstract class FoojayToolchainResolver: JavaToolchainResolver {
             platform.operatingSystem,
             platform.architecture
         )?.links
-        var uri = api.toUri(links)
-
-        // Also try x64 on M-series Macs
-        if(uri == null && platform.operatingSystem == OperatingSystem.MAC_OS && platform.architecture == Architecture.AARCH64) {
-            uri = api.toUri(api.toPackage(
-                spec.languageVersion.get(),
-                spec.vendor.get(),
-                spec.implementation.get(),
-                platform.operatingSystem,
-                Architecture.X86_64
-            )?.links)
-        }
+        val uri = api.toUri(links)
 
         return Optional.ofNullable(uri).map(JavaToolchainDownload::fromUri)
     }

--- a/foojay-resolver/src/main/kotlin/org/gradle/toolchains/foojay/FoojayToolchainResolver.kt
+++ b/foojay-resolver/src/main/kotlin/org/gradle/toolchains/foojay/FoojayToolchainResolver.kt
@@ -3,6 +3,8 @@ package org.gradle.toolchains.foojay
 import org.gradle.jvm.toolchain.JavaToolchainDownload
 import org.gradle.jvm.toolchain.JavaToolchainRequest
 import org.gradle.jvm.toolchain.JavaToolchainResolver
+import org.gradle.platform.Architecture
+import org.gradle.platform.OperatingSystem
 import java.util.*
 
 abstract class FoojayToolchainResolver: JavaToolchainResolver {
@@ -19,7 +21,19 @@ abstract class FoojayToolchainResolver: JavaToolchainResolver {
             platform.operatingSystem,
             platform.architecture
         )?.links
-        val uri = api.toUri(links)
+        var uri = api.toUri(links)
+
+        // Also try x64 on M-series Macs
+        if(uri == null && platform.operatingSystem == OperatingSystem.MAC_OS && platform.architecture == Architecture.AARCH64) {
+            uri = api.toUri(api.toPackage(
+                spec.languageVersion.get(),
+                spec.vendor.get(),
+                spec.implementation.get(),
+                platform.operatingSystem,
+                Architecture.X86_64
+            )?.links)
+        }
+
         return Optional.ofNullable(uri).map(JavaToolchainDownload::fromUri)
     }
 }

--- a/foojay-resolver/src/main/kotlin/org/gradle/toolchains/foojay/packages.kt
+++ b/foojay-resolver/src/main/kotlin/org/gradle/toolchains/foojay/packages.kt
@@ -40,6 +40,7 @@ private fun matches(p: Package, architecture: Architecture): Boolean =
         Architecture.X86 -> p.architecture in architectures32Bit
         Architecture.X86_64 -> p.architecture in architectures64Bit
         Architecture.AARCH64 -> p.architecture in architecturesArm64Bit
+                || (p.operating_system == OperatingSystem.MAC_OS.toApiValue() && p.architecture in architectures64Bit)
     }
 
 private fun hasHandledArchiveType(p: Package): Boolean {

--- a/foojay-resolver/src/main/kotlin/org/gradle/toolchains/foojay/packages.kt
+++ b/foojay-resolver/src/main/kotlin/org/gradle/toolchains/foojay/packages.kt
@@ -1,4 +1,4 @@
-@file:Suppress("ConstructorParameterNaming")
+@file:Suppress("ConstructorParameterNaming", "UnstableApiUsage")
 
 package org.gradle.toolchains.foojay
 
@@ -21,7 +21,7 @@ fun match(packages: List<Package>, architecture: Architecture): Package? {
     val candidates = packages
         .filter { p -> matches(p, architecture) }   // we filter out packages not matching the architecture the build is running on
         .filter { p -> hasHandledArchiveType(p) }   // Gradle can handle only certain archive types
-        .sortedWith(compareBy(Package::package_type, Package::lib_c_type)) // prefer JDKs over JREs & prefer "glibc" over "musl"
+        .sortedWith(compareBy(Package::package_type, Package::lib_c_type, Package::architecture)) // prefer JDKs over JREs & prefer "glibc" over "musl"
     return candidates.firstOrNull()
 }
 

--- a/foojay-resolver/src/test/kotlin/org/gradle/toolchains/foojay/FoojayApiTest.kt
+++ b/foojay-resolver/src/test/kotlin/org/gradle/toolchains/foojay/FoojayApiTest.kt
@@ -137,6 +137,14 @@ class FoojayApiTest {
         assertEquals("jdk", p.package_type)
     }
 
+    @Test
+    fun `macos arm is mapped to x64 when arm isn't available`() {
+        val p = api.match("Zulu", of(7), OperatingSystem.MAC_OS, Architecture.AARCH64)
+        assertNotNull(p)
+        assertEquals(7, p.jdk_version)
+        assertEquals("x64", p.architecture)
+    }
+
     @Suppress("LongParameterList")
     private fun assertDownloadUri(
             javaVersion: Int,
@@ -151,7 +159,9 @@ class FoojayApiTest {
         assertJavaVersion(javaVersion, actual)
         assertDistribution(vendor, actual)
         assertOperatingSystem(os, actual)
-        assertArchitecture(arch, actual)
+        if (!(os == OperatingSystem.MAC_OS && arch == Architecture.AARCH64)) {
+            assertArchitecture(arch, actual)
+        }
     }
 
     private fun assertJavaVersion(javaVersion: Int, actual: Package) {

--- a/foojay-resolver/src/test/kotlin/org/gradle/toolchains/foojay/FoojayApiTest.kt
+++ b/foojay-resolver/src/test/kotlin/org/gradle/toolchains/foojay/FoojayApiTest.kt
@@ -37,17 +37,25 @@ class FoojayApiTest {
         @Suppress("DEPRECATION")
         @JvmStatic
         fun getData(): List<Arguments> = listOf(
+          Arguments.of(8, any(), false, OperatingSystem.MAC_OS, Architecture.X86_64),
           Arguments.of(8, any(), false, OperatingSystem.MAC_OS, Architecture.AARCH64),
-          Arguments.of(11, ADOPTIUM, false, OperatingSystem.MAC_OS, Architecture.AARCH64),
-          Arguments.of(11, GRAAL_VM, false, OperatingSystem.MAC_OS, Architecture.AARCH64),
-          Arguments.of(16, any(), true, OperatingSystem.MAC_OS, Architecture.X86_64),
-          Arguments.of(16, IBM, true, OperatingSystem.MAC_OS, Architecture.X86_64),
-          Arguments.of(16, IBM_SEMERU, true, OperatingSystem.MAC_OS, Architecture.X86_64),
-          Arguments.of(16, GRAAL_VM, false, OperatingSystem.LINUX, Architecture.X86_64),
-          Arguments.of(16, any(), false, OperatingSystem.LINUX, Architecture.X86_64),
-          Arguments.of(16, any(), true, OperatingSystem.LINUX, Architecture.X86_64),
+          Arguments.of(17, any(), false, OperatingSystem.MAC_OS, Architecture.X86_64),
+          Arguments.of(17, any(), false, OperatingSystem.MAC_OS, Architecture.AARCH64),
+          Arguments.of(17, ADOPTIUM, false, OperatingSystem.MAC_OS, Architecture.AARCH64),
+          Arguments.of(17, GRAAL_VM, false, OperatingSystem.MAC_OS, Architecture.AARCH64),
+          Arguments.of(21, any(), true, OperatingSystem.MAC_OS, Architecture.X86_64),
+          Arguments.of(21, IBM, true, OperatingSystem.MAC_OS, Architecture.X86_64),
+          Arguments.of(21, IBM_SEMERU, true, OperatingSystem.MAC_OS, Architecture.X86_64),
+
+          Arguments.of(17, GRAAL_VM, false, OperatingSystem.LINUX, Architecture.X86_64),
+          Arguments.of(17, any(), false, OperatingSystem.LINUX, Architecture.X86_64),
+          Arguments.of(17, any(), true, OperatingSystem.LINUX, Architecture.X86_64),
+          Arguments.of(21, GRAAL_VM, false, OperatingSystem.LINUX, Architecture.X86_64),
+
+          Arguments.of(8, any(), false, OperatingSystem.WINDOWS, Architecture.X86_64),
           Arguments.of(8, GRAAL_VM, false, OperatingSystem.WINDOWS, Architecture.X86_64),
-          Arguments.of(20, GRAAL_VM, false, OperatingSystem.LINUX, Architecture.X86_64),
+          Arguments.of(17, any(), false, OperatingSystem.WINDOWS, Architecture.X86_64),
+          Arguments.of(17, GRAAL_VM, false, OperatingSystem.WINDOWS, Architecture.X86_64),
         )
     }
 
@@ -139,10 +147,13 @@ class FoojayApiTest {
 
     @Test
     fun `macos arm is mapped to x64 when arm isn't available`() {
-        val p = api.match("Zulu", of(7), OperatingSystem.MAC_OS, Architecture.AARCH64)
-        assertNotNull(p)
-        assertEquals(7, p.jdk_version)
-        assertEquals("x64", p.architecture)
+        // RISC architecture is preferred when available
+        val p1 = assertDownloadUri(17, AZUL, false, OperatingSystem.MAC_OS, Architecture.AARCH64)
+        assertEquals("aarch64", p1.architecture)
+
+        // X86 architecture is provided when RISC is not available
+        val p2 = assertDownloadUri(7, AZUL, false, OperatingSystem.MAC_OS, Architecture.AARCH64)
+        assertEquals("x64", p2.architecture)
     }
 
     @Suppress("LongParameterList")
@@ -152,16 +163,15 @@ class FoojayApiTest {
             isJ9: Boolean,
             os: OperatingSystem,
             arch: Architecture
-    ) {
+    ): Package {
         val actual = api.toPackage(of(javaVersion), vendor, if (isJ9) J9 else VENDOR_SPECIFIC, os, arch)
         assertNotNull(actual)
         assertNotNull(actual.links.pkg_download_redirect)
         assertJavaVersion(javaVersion, actual)
         assertDistribution(vendor, actual)
         assertOperatingSystem(os, actual)
-        if (!(os == OperatingSystem.MAC_OS && arch == Architecture.AARCH64)) {
-            assertArchitecture(arch, actual)
-        }
+        assertArchitecture(os, arch, actual)
+        return actual
     }
 
     private fun assertJavaVersion(javaVersion: Int, actual: Package) {
@@ -173,16 +183,13 @@ class FoojayApiTest {
 
     private fun assertDistribution(vendor: JvmVendorSpec, actual: Package) {
         var expectedValue = vendor.toString().replace("_", "").lowercase()
-        if (expectedValue == "ibm") {
-            expectedValue = "semeru"
-        } else if (expectedValue == "graalvm community") {
-            expectedValue = "graalvm_ce"
+        expectedValue = when (expectedValue) {
+            "ibm" -> "semeru"
+            "azul zulu" -> "zulu"
+            else -> expectedValue
         }
 
-        var actualValue = actual.distribution
-        if (actualValue == "graalvm_community") {
-            actualValue = "graalvm_ce"
-        }
+        val actualValue = actual.distribution
 
         assertTrue(vendor.matches(actualValue) || actualValue.startsWith(expectedValue),
             "Expected vendor spec ($expectedValue) doesn't match actual distribution (${actualValue}), ${moreDetailsAt(actual)}"
@@ -197,11 +204,13 @@ class FoojayApiTest {
         )
     }
 
-    private fun assertArchitecture(arch: Architecture, actual: Package) {
+    private fun assertArchitecture(os: OperatingSystem, arch: Architecture, actual: Package) {
         val expectedValues = when (arch) {
             Architecture.X86 -> architectures32Bit
             Architecture.X86_64 -> architectures64Bit
-            Architecture.AARCH64 -> architecturesArm64Bit
+            Architecture.AARCH64 ->
+                if (os == OperatingSystem.MAC_OS) architecturesArm64Bit + architectures64Bit
+                else architecturesArm64Bit
         }
         val actualValue = actual.architecture
         assertTrue(expectedValues.contains(actualValue),


### PR DESCRIPTION
Currently the plugin won't recognize that this is possible, making old java versions unusable without manually installing them.

closes #17 