### PR TITLE
Fix dependency submission failures in PR from the forked repo

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,13 +1,14 @@
-name: Dependency Submission
+name: Generate and save dependency graph
 
 on:
   workflow_dispatch:
   push:
     branches:
       - main
+  pull_request:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   dependency-submission:
@@ -20,5 +21,7 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: 21
-    - name: Generate and submit dependency graph
+    - name: Generate and save dependency graph
       uses: gradle/actions/dependency-submission@v4
+      with:
+        dependency-graph: generate-and-upload

--- a/.github/workflows/submit-dependency-graph.yml
+++ b/.github/workflows/submit-dependency-graph.yml
@@ -1,0 +1,19 @@
+name: Download and submit dependency graph
+
+on:
+  workflow_run:
+    workflows: ['Generate and save dependency graph']
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: write
+
+jobs:
+  submit-dependency-graph:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download and submit dependency graph
+      uses: gradle/actions/dependency-submission@v4
+      with:
+        dependency-graph: download-and-submit 


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle-private/issues/4556

The current dependency graph submission workflow fails when running on pull requests from forked repositories due to GitHub's security restrictions. 

```
Error: HttpError: Dependency submission failed for dependency-graph-reports/dependency_review_for_pull_requests-dependency-submission.json.
Resource not accessible by integration
Please ensure that the 'contents: write' permission is available for the workflow job.
Note that this permission is never available for a 'pull_request' trigger from a repository fork.
        
HttpError: Dependency submission failed for dependency-graph-reports/dependency_review_for_pull_requests-dependency-submission.json.
Resource not accessible by integration
Please ensure that the 'contents: write' permission is available for the workflow job.
Note that this permission is never available for a 'pull_request' trigger from a repository fork.
```

According to [the doc](https://github.com/gradle/actions/blob/main/docs/dependency-submission.md#usage-with-pull-requests-from-public-forked-repositories), we need to split the dependency graph workflow into two parts:
1. A generation workflow (`dependency-submission.yml`) that runs with read-only permissions to generate and save the dependency graph as an artifact.
2. A submission workflow (`submit-dependency-graph.yml`) that runs in the base repository context to download and submit the generated dependency graph.

The second workflow runs with the context and permissions of the base repository. It's not running arbitrary code from the PR, it's only processing a dependency graph that was generated earlier.
