### PR TITLE
Shade implementation dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Plugin now compiled with Java 17, meaning it requires that version or higher to run
 - Removed direct references to deprecated JvmVendorSpec.IBM_SEMERU, to prepare for Gradle 9 compatibility.
+- Implementation dependencies are now shaded to reduce potential conflicts with other plugins
 
 ### Deprecated
 

--- a/foojay-resolver/build.gradle.kts
+++ b/foojay-resolver/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     signing
     id("com.gradle.plugin-publish") version "1.2.1"
     id("io.gitlab.arturbosch.detekt") version "1.23.6"
+    id("com.gradleup.shadow") version "8.3.6"
 }
 
 group = "org.gradle.toolchains"
@@ -17,6 +18,17 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)
     }
+}
+
+tasks.shadowJar {
+    isEnableRelocation = true
+    archiveClassifier = ""
+    minimize()
+
+    // Clean up some of the unwanted files from gson shading
+    includeEmptyDirs = false
+    exclude("**/module-info.class")
+    exclude("META-INF/maven/**")
 }
 
 detekt {


### PR DESCRIPTION
This makes sure that those dependencies cannot conflict with other similar dependencies from different plugins.

Fixes #99