### PR TITLE
Adopt io.github.gradle.gradle-enterprise-conventions-plugin

### DIFF
--- a/foojay-resolver/build.gradle.kts
+++ b/foojay-resolver/build.gradle.kts
@@ -96,6 +96,7 @@ tasks.check {
 }
 
 val readReleaseNotes by tasks.registering {
+    notCompatibleWithConfigurationCache("This task modifies other tasks")
     description = "Ensure we've got some release notes handy"
     doLast {
         val releaseNotesFile = file("release-notes-$version.txt")
@@ -110,6 +111,7 @@ val readReleaseNotes by tasks.registering {
 }
 
 tasks.publishPlugins {
+    notCompatibleWithConfigurationCache("This task still has a project reference")
     dependsOn(readReleaseNotes)
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.parallel=true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,16 +1,7 @@
 plugins {
-    id("com.gradle.develocity") version "3.17"
+    id("com.gradle.develocity") version "4.0.1"
+    id("io.github.gradle.gradle-enterprise-conventions-plugin").version("0.10.2")
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
-}
-
-develocity {
-    buildScan {
-        termsOfUseUrl = "https://gradle.com/terms-of-service"
-        termsOfUseAgree = "yes"
-        // TODO: workaround for https://github.com/gradle/gradle/issues/22879.
-        val isCI = providers.environmentVariable("CI").isPresent
-        publishing.onlyIf { isCI }
-    }
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
This allows scans to be published to ge.gradle.org and to benefit from the remote build cache over there.

Also turn on caching, parallel, CC and parallel CC features. While CC is
 not 100% supported, it should help local development and testing.